### PR TITLE
Fix missing initialization options for server

### DIFF
--- a/INITIALIZATION_FIX.md
+++ b/INITIALIZATION_FIX.md
@@ -1,0 +1,57 @@
+# Fix for InitializationOptions Error
+
+## Problem
+
+The server was failing with a `pydantic` validation error when trying to create an `InitializationOptions` object:
+
+```
+pydantic_core._pydantic_core.ValidationError: 3 validation errors for InitializationOptions
+server_name
+  Field required [type=missing, input_value={}, input_type=dict]
+server_version
+  Field required [type=missing, input_value={}, input_type=dict]
+capabilities
+  Field required [type=missing, input_value={}, input_type=dict]
+```
+
+## Root Cause
+
+In `main.py` line 635, the code was trying to instantiate `InitializationOptions` without any parameters:
+
+```python
+InitializationOptions()
+```
+
+However, `InitializationOptions` is a Pydantic model that requires three mandatory fields:
+- `server_name`: The name of the MCP server
+- `server_version`: The version of the server
+- `capabilities`: A dictionary describing the server's capabilities
+
+## Solution
+
+The fix was to provide all required fields when creating the `InitializationOptions` object:
+
+```python
+InitializationOptions(
+    server_name=self.config.server.name,
+    server_version=self.config.server.version,
+    capabilities=self.server.get_capabilities()
+)
+```
+
+This change was applied to `main.py` at lines 635-639.
+
+## Implementation Details
+
+The fix uses:
+- `self.config.server.name`: Gets the server name from the configuration (default: "pc-control-mcp")
+- `self.config.server.version`: Gets the server version from the configuration (default: "2.0.0")
+- `self.server.get_capabilities()`: Calls the server's method to get its capabilities dynamically
+
+## Expected Result
+
+After this fix, the server should successfully initialize and run without the validation error. The server will properly communicate its identity and capabilities to MCP clients.
+
+## Additional Notes
+
+This is a common pattern in MCP servers where the `InitializationOptions` must be properly populated with the server's metadata. The MCP protocol uses this information during the handshake process to establish what features the server supports.

--- a/main.py
+++ b/main.py
@@ -632,7 +632,11 @@ class PCControlServer:
                 await self.server.run(
                     read_stream,
                     write_stream,
-                    InitializationOptions()
+                    InitializationOptions(
+                        server_name=self.config.server.name,
+                        server_version=self.config.server.version,
+                        capabilities=self.server.get_capabilities()
+                    )
                 )
                 print(f"DEBUG: Server finished")
         except Exception as e:

--- a/test_initialization_fix.py
+++ b/test_initialization_fix.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Test script to demonstrate the InitializationOptions fix"""
+
+from pydantic import BaseModel
+from typing import Dict, Any, Optional
+
+# Simulating the InitializationOptions model based on the error
+class InitializationOptions(BaseModel):
+    server_name: str
+    server_version: str
+    capabilities: Dict[str, Any]
+
+# Test the original code that was failing
+try:
+    print("Testing original code (should fail):")
+    options = InitializationOptions()  # This should fail
+except Exception as e:
+    print(f"✗ Error (as expected): {type(e).__name__}")
+    print(f"  Details: {e}")
+
+# Test the fixed code
+try:
+    print("\nTesting fixed code (should work):")
+    options = InitializationOptions(
+        server_name="pc-control-mcp",
+        server_version="2.0.0",
+        capabilities={
+            "tools": {"list": []},
+            "resources": {"list": []},
+            "prompts": {"list": []}
+        }
+    )
+    print(f"✓ Success! Created InitializationOptions:")
+    print(f"  - server_name: {options.server_name}")
+    print(f"  - server_version: {options.server_version}")
+    print(f"  - capabilities: {options.capabilities}")
+except Exception as e:
+    print(f"✗ Unexpected error: {type(e).__name__}: {e}")
+
+# Show the fix that was applied
+print("\n📝 The fix applied to main.py:")
+print("BEFORE:")
+print("  InitializationOptions()")
+print("\nAFTER:")
+print("  InitializationOptions(")
+print("      server_name=self.config.server.name,")
+print("      server_version=self.config.server.version,")
+print("      capabilities=self.server.get_capabilities()")
+print("  )")


### PR DESCRIPTION
Initialize `InitializationOptions` with required server details to resolve validation errors.

The `InitializationOptions` Pydantic model was being instantiated without its mandatory `server_name`, `server_version`, and `capabilities` fields, leading to a `ValidationError`. This PR populates these fields using values from the server's configuration and a call to `self.server.get_capabilities()` to ensure proper MCP server initialization.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b9a2849-f592-43b3-9afd-5657fb1e507f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9b9a2849-f592-43b3-9afd-5657fb1e507f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

