### PR TITLE
Fix config attribute error in server

### DIFF
--- a/main.py
+++ b/main.py
@@ -633,8 +633,8 @@ class PCControlServer:
                     read_stream,
                     write_stream,
                     InitializationOptions(
-                        server_name=self.config.server.name,
-                        server_version=self.config.server.version,
+                        server_name=self.config.config.server.name,
+                        server_version=self.config.config.server.version,
                         capabilities=self.server.get_capabilities()
                     )
                 )


### PR DESCRIPTION
Fixes `AttributeError` by correcting the access path to server configuration within `ConfigManager`.

---
<a href="https://cursor.com/background-agent?bcId=bc-da5f4cd1-c37d-44af-9523-84a69e36d60c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da5f4cd1-c37d-44af-9523-84a69e36d60c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

